### PR TITLE
Fix typo. Change blog descr.

### DIFF
--- a/content/posts/monady-monoidy-funktory-endofunktory.md
+++ b/content/posts/monady-monoidy-funktory-endofunktory.md
@@ -49,7 +49,7 @@ let x = Box 666 // x: Box<int>
 printfn "%A" x // Box 666
 ```
 
-Idąc dalej, `endofunktor` to `funktor`, lecz który jak już wspomniałem - działą w obrębie jednej kategorii, np. funkcja `SaleTransaction` -> `Sale Transaction`.
+Idąc dalej, `endofunktor` to `funktor`, lecz który jak już wspomniałem - działa w obrębie jednej kategorii, np. funkcja `SaleTransaction` -> `Sale Transaction`.
 
 By łatwiej to zobrazować, przyjmijmy, że mamy poniższy typ reprezentujący transakcję:
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -16,7 +16,7 @@ export default defineNuxtConfig({
       meta: [
         {
           name: 'description',
-          content: 'Personal blog',
+          content: 'Senior DevOps Engineer @ Private blog',
         },
       ],
     },


### PR DESCRIPTION
Fix typo, change the blog description in Nuxt Config.